### PR TITLE
Make portable to systems without /bin/bash

### DIFF
--- a/splain
+++ b/splain
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -z "$1" ]; then
     echo "Usage: splain <command>"


### PR DESCRIPTION
On FreeBSD bash is in /usr/local/bin.  Use the common /usr/bin/env trick
to find bash regardless of where it is installed.